### PR TITLE
Drop Laravel 8, add Laravel 10, require PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "laravel/framework": "^8.0 || ^9.0",
+        "php": "^8.1",
+        "laravel/framework": "^9.0 || ^10.0",
         "laravel/nova": "^4.0"
     },
     "autoload": {


### PR DESCRIPTION
A version bump for Laravel 10. Also bumps the minimum PHP to 8.1 (since that's required for L10), and drops L8 (since [it's now EOL](https://laravelversions.com/en)).